### PR TITLE
Get rid of pink bar that appeared due to grid spacing and vw vs percent

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -192,7 +192,9 @@ class App extends Component {
                 <img src={tofuHero} alt="Tofu Hero" id="tofu-hero"/>
                 <h2>{headline}</h2>
                 {this.state.hasSearched &&
-                <Grid container spacing={3} justify={"center"}>
+                <Grid container justify={"center"} style={{rowGap: '12px',}}>
+                    {/* TODO: standarize grid items so rowGap is placed appropriately between rows, 
+                    and define grid item rows accordingly/consistently (ie. pull header text into or out of child components; standarize). */}
                     <Grid item xs={12} sm={summarySize}>
                         <Summary
                             totalImpact={this.state.results.totalImpact}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -42,7 +42,7 @@ label {
 
 #header {
     display: flex;
-    width: 100vw;
+    width: 100%;
     padding: 10px 0px;
 }
 


### PR DESCRIPTION
I got rid of the pink bar appearing to the far right that wasn't fully resolved in #3. This time it is due to grid spacing and the usage of vw vs %.

You can learn more about the different between vw and % here, and why vw results in horizontal scrollbar:
https://stackoverflow.com/questions/25225682/difference-between-width100-and-width100vw/25225716
https://stackoverflow.com/questions/23367345/100vw-causing-horizontal-overflow-but-only-if-more-than-one

Grid spacing caused issues because it adds space to both horizontal and vertical.
We may want to use a new feature in MUI instead: https://github.com/mui-org/material-ui/pull/26559 -- separate rowSpacing and columnSpacing is a new feature in MUI grid.
Meanwhile, I used CSS rowGap instead to define spacing only between rows. 

However, we'll need to more consistently define what makes rows (Grid items) in App.js. Right now, whether a header is part of child component or not is NOT standardized, so spacing can look off and inconsistent (eg. the title "How do I compare..." is part of Comparison component, but "Tell Me how I can do better" is a separate grid item from bar chart and recommendations -- instead, "Tell me how I can do better" should be part of a container or div with bar chart and recommendations to form one section).