### PR TITLE
Fix improper commenting syntax in Grocery list

### DIFF
--- a/frontend/src/GroceryList.js
+++ b/frontend/src/GroceryList.js
@@ -459,7 +459,7 @@ class GroceryList extends Component {
                             }}
                         />
 
-                        // Items in grocery list
+                        {/* Items in grocery list */}
                         <form style={{width: '100%'}}>
                             <List>
                                 {list}


### PR DESCRIPTION
A very minor fix in commenting syntax. Improper syntax caused extra text "// Items in grocery list" to be displayed to website.