### PR TITLE
Disallow negative value inputs in Grocery list amount, and make units a dropdown selection

### DIFF
--- a/frontend/src/GroceryList.js
+++ b/frontend/src/GroceryList.js
@@ -23,8 +23,8 @@ const NATIVE_API_ADDRESS =  process.env.API_HOST || "http://localhost:8000";
 const ALL_UNITS = ['milliliter', 'ml', 'liter', 'l', 'gram', 'g', 'kilogram', 'kg', 'cup', 
                     'tablespoon', 'teaspoon', 'ounce', 'pound', 'quart', 
                     'pint', 'dash', 'pinch', 'handful', 'fistful', 'smidgen', 'ea'];
-// Limited selection of units visible for sake of dropdown menu
-const VISIBLE_UNITS = ['tablespoon', 'teaspoon', 'ounce', 'cup', 'pint', 'quart', 'milliliter', 'gram',
+// Limited selection of units selectable for sake of dropdown menu, in order
+const SELECTABLE_UNITS = ['tablespoon', 'teaspoon', 'ounce', 'cup', 'pint', 'quart', 'milliliter', 'gram',
                     'pound', 'pinch', 'ea'];
 
 const styles = {
@@ -680,6 +680,18 @@ class GroceryListItem extends Component{
                     />
                 </Grid>
                 <Grid item xs sm className={this.props.classes.inputGrid}>
+                    {/* TODO: autocomplete */}
+                    {/* https://material-ui.com/components/autocomplete/ Use filter options to autocomplete */}
+                    {/* <Autocomplete
+                            id="food_name"
+                            required
+                            options={this.state._FOOD_ALIASES}
+                            getOptionLabel={(option) => option.name}
+                            filterOptions={createFilterOptions({stringify: option => option.aliases})}
+                            renderInput={(params) => <TextField {...params} label="food" required />}
+                            autoHighlight
+                            onChange={this.handleChange}
+                        /> */}
                     <Select value={this.props.unit}
                             id={`${this.props.ingredient}_unit`}
                             onChange={this.handleUnitChange}
@@ -690,8 +702,8 @@ class GroceryListItem extends Component{
                                                             key={unit} 
                                                             id={`${this.props.ingredient}_unit`}
                                                             style={{
-                                                                // Allow units in ALL_UNITS, but only those in VISIBLE_UNITS are visible in selection menu
-                                                                display: (VISIBLE_UNITS.includes(unit)) ? 'block' : 'none'
+                                                                // Allow units in ALL_UNITS, but only those in SELECTABLE_UNITS are visible and selectable in selection menu
+                                                                display: (SELECTABLE_UNITS.includes(unit)) ? 'block' : 'none'
                                                                 }}>
                                                                     {unit}
                                                                 </MenuItem>)}

--- a/frontend/src/GroceryList.js
+++ b/frontend/src/GroceryList.js
@@ -19,11 +19,12 @@ import { ContactSupport } from "@material-ui/icons";
 const GHGI_API_ADDRESS = 'https://api.sexytofu.org/api.ghgi.org:443';
 const NATIVE_API_ADDRESS =  process.env.API_HOST || "http://localhost:8000";
 // Matches all GHGI units from https://github.com/ghgindex/ghgi/blob/main/ghgi/parser.py
-// const ALL_UNITS = ['milliliter', 'liter', 'gram', 'kilogram', 'cup', 
-//                     'tablespoon', 'teaspoon', 'ounce', 'pound', 'quart', 
-//                     'pint', 'dash', 'pinch', 'handful', 'fistful', 'smidgen', 'ea'];
-// Limited selection of units for sake of dropdown menu
-const ALL_UNITS = ['milliliter', 'gram', 'cup', 
+// All units we support
+const ALL_UNITS = ['milliliter', 'liter', 'gram', 'kilogram', 'cup', 
+                    'tablespoon', 'teaspoon', 'ounce', 'pound', 'quart', 
+                    'pint', 'dash', 'pinch', 'handful', 'fistful', 'smidgen', 'ea'];
+// Limited selection of units visible for sake of dropdown menu
+const VISIBLE_UNITS = ['milliliter', 'gram', 'cup', 
                     'tablespoon', 'teaspoon', 'ounce', 'pound', 'quart', 
                     'pint', 'pinch', 'ea'];
 
@@ -686,7 +687,15 @@ class GroceryListItem extends Component{
                             variant="outlined"
                             className={textFieldClass + ' ' + this.props.classes.select}
                             >
-                        {ALL_UNITS.map((unit) => <MenuItem value={unit} key={unit} id={`${this.props.ingredient}_unit`}>{unit}</MenuItem>)}
+                        {ALL_UNITS.map((unit) => <MenuItem value={unit} 
+                                                            key={unit} 
+                                                            id={`${this.props.ingredient}_unit`}
+                                                            style={{
+                                                                // Allow units in ALL_UNITS, but only those in VISIBLE_UNITS are visible in selection menu
+                                                                display: (VISIBLE_UNITS.includes(unit)) ? 'block' : 'none'
+                                                                }}>
+                                                                    {unit}
+                                                                </MenuItem>)}
                     </Select>
                 </Grid>
                 <Grid item xs={1} sm={1}>

--- a/frontend/src/GroceryList.js
+++ b/frontend/src/GroceryList.js
@@ -657,7 +657,7 @@ class GroceryListItem extends Component{
                         onKeyPress={this.handleKeyPress}
                         value={this.props.ingredient}
                         size='small'
-                        label="food"
+                        placeholder="food"
                         // style={{float: "left", clear: 'both'}}
                     />
                 </Grid>
@@ -673,7 +673,7 @@ class GroceryListItem extends Component{
                         onKeyPress={this.handleKeyPress}
                         value={this.props.quantity}
                         size='small'
-                        label="quantity"
+                        placeholder="quantity"
                         // style={{float: "left", clear: 'both'}}
                     />
                 </Grid>
@@ -684,7 +684,7 @@ class GroceryListItem extends Component{
                             options={ALL_UNITS}
                             // TODO: allow different spellings for same unit eg. kg and kilogram
                             // filterOptions={createFilterOptions({stringify: option => option.aliases})}
-                            renderInput={(params) => <TextField {...params} label="unit" variant="outlined" />}
+                            renderInput={(params) => <TextField {...params} placeholder="unit" variant="outlined" />}
                             getOptionLabel={(option) => option}
                             autoHighlight
                             disableClearable

--- a/frontend/src/GroceryList.js
+++ b/frontend/src/GroceryList.js
@@ -20,13 +20,12 @@ const GHGI_API_ADDRESS = 'https://api.sexytofu.org/api.ghgi.org:443';
 const NATIVE_API_ADDRESS =  process.env.API_HOST || "http://localhost:8000";
 // Matches all GHGI units from https://github.com/ghgindex/ghgi/blob/main/ghgi/parser.py
 // All units we support
-const ALL_UNITS = ['milliliter', 'liter', 'gram', 'kilogram', 'cup', 
+const ALL_UNITS = ['milliliter', 'ml', 'liter', 'l', 'gram', 'g', 'kilogram', 'kg', 'cup', 
                     'tablespoon', 'teaspoon', 'ounce', 'pound', 'quart', 
                     'pint', 'dash', 'pinch', 'handful', 'fistful', 'smidgen', 'ea'];
 // Limited selection of units visible for sake of dropdown menu
-const VISIBLE_UNITS = ['milliliter', 'gram', 'cup', 
-                    'tablespoon', 'teaspoon', 'ounce', 'pound', 'quart', 
-                    'pint', 'pinch', 'ea'];
+const VISIBLE_UNITS = ['tablespoon', 'teaspoon', 'ounce', 'cup', 'pint', 'quart', 'milliliter', 'gram',
+                    'pound', 'pinch', 'ea'];
 
 const styles = {
     root: {


### PR DESCRIPTION
Features:

- Grocery list amount: typing input cannot be made negative, and some check to disallow non-number inputs eg. "3-3", "2.34.2" etc.
- Units is now a selection dropdown rather than freeform text input

Issues:

- Character "-" is still typeable as leading character, when it should not be typeable at all in grocery list amount
- It is still possible to submit non-number amounts eg. ".", "-", and blank
- need to disable focus and hover style borders on selection menu

![image](https://user-images.githubusercontent.com/31525446/129145526-62a01036-bf14-401c-97ac-a476f7f868b8.png)

- (from dev) Submitting grocery list amount of "0" causes site to crash due to undefined value

Discussion:

- What kind of units should we allow for selection dropdown? And in what order?
(Current units:) 
![image](https://user-images.githubusercontent.com/31525446/129145929-76cfb070-f6dc-4155-823d-ad8b0e19d790.png)
