### PR TITLE
Tina/about Add link to 'about us' and minor fix

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -299,7 +299,9 @@ class App extends Component {
                     <a href="#">
                         <img src={logo} alt="Sexy Tofu" id="logo" onClick={this.onLogoClicked}/>
                     </a>
-                    {this.state.hasSearched && <img src={tofuHero} alt="Tofu Hero" id="tofu-hero" style={{height: '61px'}}/>}
+                    <a href="https://info.sexytofu.org/" target="_blank" style={{color: "white"}}>
+                        <Typography variant="body1" style={{margin: '12px'}}>About</Typography>
+                    </a>
                 </div>
                 <div id="bottomFloat">
                     <Feedback link={FEEDBACK_FORM}/>

--- a/frontend/src/Feedback.js
+++ b/frontend/src/Feedback.js
@@ -11,7 +11,7 @@ const styles = {
     root: {
         width:'100%', 
         display: 'inline-flex', 
-        justifyContent: 'flex-end',
+        justifyContent: 'flex-start',
         '& .MuiButton-contained:hover': {
             // Button hover style
             color: '#2e3032',
@@ -25,9 +25,9 @@ const styles = {
         textTransform: "none",
         color: '#53575B',
         backgroundColor: '#F9F7F7',
-        borderRadius: '18px 0px 0px 18px',
+        borderRadius: '0px 18px 18px 0px',
         border: '3px solid #F2F2F2',
-        borderRight: 'none',
+        borderLeft: 'none',
         marginBottom: '1ch',
         // transform: "translateX(80%)",
         // animation: '$slideIn 0.5s ease-in-out',

--- a/frontend/src/Summary.js
+++ b/frontend/src/Summary.js
@@ -119,7 +119,7 @@ function Summary(props) {
                             <span className={classes.highlight}>{props.totalShowerUse.toFixed(1)}</span>&nbsp; 8-minute&nbsp;
                             {pluralize('shower', 'showers', props.totalShowerUse)} taken
                         </Typography>
-                    </Grid>`
+                    </Grid>
                 </Grid>
             </div>}
         </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -51,6 +51,11 @@ a:link:hover {
     color: #ffdbec;
 }
 
+a:visited:hover {
+    background-color: #F251B1;
+    color: #ffdbec;
+}
+
 .profile{
     width: 200px;
     height: 200px;


### PR DESCRIPTION
- link to about us page, assuming it's at https://info.sexytofu.org/
- Get rid of extra floating text in summary
- left align feedback button
- minor style fix of visited link