### PR TITLE
Tina/slider label Mobile responsiveness - fix slider label position and control keyboard focus

### DIFF
--- a/frontend/src/Comparison.js
+++ b/frontend/src/Comparison.js
@@ -99,11 +99,14 @@ const scaleStyles = makeStyles((theme) => ({
             color: '#000',
           },
         // Change position of label accordingly when vertical slider
-        '@media only screen and (max-width: 600px)': {
+        '@media screen and (max-width: 600px)': {
             top: '6px',
             // marginRight: '230px',
-            // Try to make responsize for iPhone
-            marginRight: '15rem',
+            // Try to make responsive for iPhone...possible this media query doesn't work on iOS?
+            // https://stackoverflow.com/questions/8549529/what-is-the-difference-between-screen-and-only-screen-in-media-queries more on media queries on mobile
+            // https://stackoverflow.com/questions/7859336/why-are-my-css3-media-queries-not-working-on-mobile-devices
+            // marginRight: '15rem',
+            marginLeft: '-14.8rem',
         },
     },
     // Each persona's mark on the scale

--- a/frontend/src/Comparison.js
+++ b/frontend/src/Comparison.js
@@ -101,7 +101,9 @@ const scaleStyles = makeStyles((theme) => ({
         // Change position of label accordingly when vertical slider
         '@media only screen and (max-width: 600px)': {
             top: '6px',
-            marginRight: '230px',
+            // marginRight: '230px',
+            // Try to make responsize for iPhone
+            marginRight: '15rem',
         },
     },
     // Each persona's mark on the scale

--- a/frontend/src/Comparison.js
+++ b/frontend/src/Comparison.js
@@ -97,7 +97,7 @@ const scaleStyles = makeStyles((theme) => ({
         '& *': {
             background: 'transparent',
             // color: '#000',
-            color: 'blue',
+            color: 'green',
           },
         // Change position of label accordingly when vertical slider
         '@media screen and (max-width: 600px)': {
@@ -107,8 +107,10 @@ const scaleStyles = makeStyles((theme) => ({
             // https://stackoverflow.com/questions/8549529/what-is-the-difference-between-screen-and-only-screen-in-media-queries more on media queries on mobile
             // https://stackoverflow.com/questions/7859336/why-are-my-css3-media-queries-not-working-on-mobile-devices
             // marginRight: '15rem',
+
             // marginLeft: '-14.8rem', // Causes a big change on mobile, but different from desktop!
-            marginLeft: '-230px', // Maybe issue is marginLeft vs Right?
+            // marginLeft: '-230px', // Same problem as above line -> an issue w/ marginLeft ?
+            left: '-124px',
         },
     },
     // Each persona's mark on the scale

--- a/frontend/src/Comparison.js
+++ b/frontend/src/Comparison.js
@@ -96,17 +96,18 @@ const scaleStyles = makeStyles((theme) => ({
         // Hide default valueLabel teardrop shape
         '& *': {
             background: 'transparent',
-            color: '#000',
+            // color: '#000',
+            color: 'red',
           },
         // Change position of label accordingly when vertical slider
         '@media screen and (max-width: 600px)': {
             top: '6px',
-            // marginRight: '230px',
+            marginRight: '230px',
             // Try to make responsive for iPhone...possible this media query doesn't work on iOS?
             // https://stackoverflow.com/questions/8549529/what-is-the-difference-between-screen-and-only-screen-in-media-queries more on media queries on mobile
             // https://stackoverflow.com/questions/7859336/why-are-my-css3-media-queries-not-working-on-mobile-devices
             // marginRight: '15rem',
-            marginLeft: '-14.8rem',
+            // marginLeft: '-14.8rem',
         },
     },
     // Each persona's mark on the scale

--- a/frontend/src/Comparison.js
+++ b/frontend/src/Comparison.js
@@ -97,17 +97,18 @@ const scaleStyles = makeStyles((theme) => ({
         '& *': {
             background: 'transparent',
             // color: '#000',
-            color: 'red',
+            color: 'blue',
           },
         // Change position of label accordingly when vertical slider
         '@media screen and (max-width: 600px)': {
             top: '6px',
-            marginRight: '230px',
+            // marginRight: '230px', // No change on mobile...
             // Try to make responsive for iPhone...possible this media query doesn't work on iOS?
             // https://stackoverflow.com/questions/8549529/what-is-the-difference-between-screen-and-only-screen-in-media-queries more on media queries on mobile
             // https://stackoverflow.com/questions/7859336/why-are-my-css3-media-queries-not-working-on-mobile-devices
             // marginRight: '15rem',
-            // marginLeft: '-14.8rem',
+            // marginLeft: '-14.8rem', // Causes a big change on mobile, but different from desktop!
+            marginLeft: '-230px', // Maybe issue is marginLeft vs Right?
         },
     },
     // Each persona's mark on the scale

--- a/frontend/src/Comparison.js
+++ b/frontend/src/Comparison.js
@@ -96,20 +96,11 @@ const scaleStyles = makeStyles((theme) => ({
         // Hide default valueLabel teardrop shape
         '& *': {
             background: 'transparent',
-            // color: '#000',
-            color: 'green',
+            color: '#000',
           },
         // Change position of label accordingly when vertical slider
-        '@media screen and (max-width: 600px)': {
+        '@media only screen and (max-width: 600px)': {
             top: '6px',
-            // marginRight: '230px', // No change on mobile...
-            // Try to make responsive for iPhone...possible this media query doesn't work on iOS?
-            // https://stackoverflow.com/questions/8549529/what-is-the-difference-between-screen-and-only-screen-in-media-queries more on media queries on mobile
-            // https://stackoverflow.com/questions/7859336/why-are-my-css3-media-queries-not-working-on-mobile-devices
-            // marginRight: '15rem',
-
-            // marginLeft: '-14.8rem', // Causes a big change on mobile, but different from desktop!
-            // marginLeft: '-230px', // Same problem as above line -> an issue w/ marginLeft ?
             left: '-124px',
         },
     },

--- a/frontend/src/GroceryList.js
+++ b/frontend/src/GroceryList.js
@@ -202,6 +202,8 @@ class GroceryList extends Component {
             hasSearchError:false, searchErrorMessage : "",
             popperIndex: -1, popperMsg: "", popperAnchor: null
         };
+        // React DOM ref to SearchBar textField, to control focus.
+        this.textInput = React.createRef(); 
     }
 
     componentDidUpdate(prevProps, prevState) {
@@ -281,6 +283,8 @@ class GroceryList extends Component {
         }   
         if (event.key === 'Enter') {
             if (this.state.currentQuery === "") {
+                // Search current grocery list, and make SearchBar lose keyboard focus.
+                this.textInput.current.blur();
                 this.props.search(this.state.groceryList);
             } else {
                 this.addFood();
@@ -510,6 +514,7 @@ class GroceryList extends Component {
                                 buttonClass={buttonClass}
                                 addFood={this.addFood}
                                 inputGrid={this.props.classes.inputGrid}
+                                inputRef={this.textInput}
                             />
                         </Grid>
 
@@ -600,13 +605,14 @@ function SearchBar(props){
      * @param   {Object}    props.buttonClass       Style of component's Add button
      * @param   {function}  props.addFood           Callback function to add food (handle when Add pressed)
      * @param   {Object}    props.inputGrid         Style of component's Grid
+     * @param props.inputRef  React hook to control focus
      *
      * @return  {HTMLSpanElement}  HTML element for the component
      */
-    const input = React.useRef(); 
+    // const input = React.useRef(); 
 
     const setFocus = () => {
-        input.current.focus();
+        props.inputRef.current.focus();
     };
 
     return (
@@ -614,7 +620,7 @@ function SearchBar(props){
         <Grid item xs={12} sm={10} className={props.inputGrid}>
             <TextField
                 id="searchBox"
-                inputRef={input}
+                inputRef={props.inputRef}
                 autoFocus={true}
                 variant="outlined"
                 className={props.textFieldClass}

--- a/frontend/src/Recommendations.js
+++ b/frontend/src/Recommendations.js
@@ -50,12 +50,7 @@ const styles = {
             // Set default appearance to none, then added custom scroll style, to show up on MacOS
             // https://stackoverflow.com/questions/7855590/preventing-scroll-bars-from-being-hidden-for-macos-trackpad-users-in-webkit-blin
             '& -webkit-appearance' : 'none',
-            // [TODO: the following doesn't work] Make scrollbar show on IOS Safari mobile: https://stackoverflow.com/questions/22907777/make-scrollbar-visible-in-mobile-browsers
-            // '& -webkit-overflow-scrolling': 'auto',
-            // https://stackoverflow.com/questions/4168974/iphone-safari-not-showing-scroll-bars
-            // https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-overflow-scrolling not supported? Look into iScroll
-            // https://github.com/ajaxorg/ace/issues/2872
-            '& -webkit-overflow-scrolling': 'scroll',
+            // TODO: Make scrollbar show on IOS Safari mobile. Note: -webkit-overflow-scrolling is no longer supported. 
             width: '24px',
         },
         '& ::-webkit-scrollbar-track': {

--- a/frontend/src/Recommendations.js
+++ b/frontend/src/Recommendations.js
@@ -50,8 +50,12 @@ const styles = {
             // Set default appearance to none, then added custom scroll style, to show up on MacOS
             // https://stackoverflow.com/questions/7855590/preventing-scroll-bars-from-being-hidden-for-macos-trackpad-users-in-webkit-blin
             '& -webkit-appearance' : 'none',
-            // [TODO: test effectiveness] Make scrollbar show on IOS Safari mobile: https://stackoverflow.com/questions/22907777/make-scrollbar-visible-in-mobile-browsers
-            '& -webkit-overflow-scrolling': 'auto',
+            // [TODO: the following doesn't work] Make scrollbar show on IOS Safari mobile: https://stackoverflow.com/questions/22907777/make-scrollbar-visible-in-mobile-browsers
+            // '& -webkit-overflow-scrolling': 'auto',
+            // https://stackoverflow.com/questions/4168974/iphone-safari-not-showing-scroll-bars
+            // https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-overflow-scrolling not supported? Look into iScroll
+            // https://github.com/ajaxorg/ace/issues/2872
+            '& -webkit-overflow-scrolling': 'scroll',
             width: '24px',
         },
         '& ::-webkit-scrollbar-track': {


### PR DESCRIPTION
Features

- Fixed issue of incorrect position of 'Me' label of slider on certain iPhones
(to fix, changed setting position of label by using 'margin' to using 'left' position property)
- Make keyboard lose focus of SearchBar after submitting grocery list

Notes/Issues:

- Scroll bar is still not visible on mobile iOS Safari. This appears to most likely be iOS-13 specific issue -- annoyingly, Apple made the decision to hide scroll bars whenever possible:

https://stackoverflow.com/questions/59265225/always-show-scrollbar-on-safari-ios-13
I suggest looking into something like [niceScroll](https://nicescroll.areaaperta.com/demo/) or [iScroll ](https://iscrolljs.com/)to custom build scrollbar if we are intent on making it always visible.

Questions

- To test fixes on mobile, I made a lot of unnecessary commits so changes would be visible on the website (so then I could access by phone). However, this ends up adding clutter in unnecessary commits, and also added wait time between testing (waited for website to update). Was there a better way I could've tested?
- In your opinion, why did this particular issue (positioning of slider label) only present itself in certain environments but not others?
- Your thoughts on the scrollbar visibility?
- So far, I learned all these can affect how a website appears: browser, device, OS (version matters). That's a lot to keep track of. How do we ensure our website works for most combinations of these efficiently?