### PR TITLE
Tina/cookie banner Obtain user consent for cookies, and separate privacy policy page

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5160,6 +5160,12 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
+    "js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==",
+      "dev": true
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6893,6 +6899,16 @@
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
+      }
+    },
+    "react-cookie-consent": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/react-cookie-consent/-/react-cookie-consent-6.3.0.tgz",
+      "integrity": "sha512-ynDLIJwedf0btR3sHsrRdcng6KWi9lJKLOUxo7BCof0F3DAFPxBRlAgUy4u1UdiPYR0gcjYHGVu5hE+22IWKmg==",
+      "dev": true,
+      "requires": {
+        "js-cookie": "^2.2.1",
+        "prop-types": "^15.7.2"
       }
     },
     "react-dom": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,8 +2,8 @@
   "name": "sexy-tofu",
   "version": "1.0.0",
   "scripts": {
-    "dev": "parcel src/index.html src/addReco/addReco.html",
-    "build": "parcel build src/index.html src/addReco/addReco.html",
+    "dev": "parcel src/index.html src/addReco/addReco.html src/policy/privacyPolicy.html",
+    "build": "parcel build src/index.html src/addReco/addReco.html src/policy/privacyPolicy.html",
     "start": "npm run dev && live-server dist"
   },
   "keywords": [],

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-stage-0": "^6.24.1",
     "react": "^17.0.2",
+    "react-cookie-consent": "^6.3.0",
     "react-dom": "^17.0.2",
     "react-hot-loader": "^4.13.0"
   }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -5,6 +5,7 @@ import GroceryList from "./GroceryList";
 import tofuHero from "./assets/tofu-hero.gif";
 import logo from "./assets/logo-text.png";
 
+import CookieBanner from "./CookieBanner";
 import Recommendations from "./Recommendations";
 import BarChart from "./BarChart";
 import Comparison from "./Comparison";
@@ -411,6 +412,7 @@ class App extends Component {
                         key={this.state.grocListKey}
                     />
                 </div>
+                <CookieBanner />
             </div>
             </MuiThemeProvider>
         );

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -19,6 +19,7 @@ import {MuiThemeProvider, createMuiTheme} from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
 import Typography from "@material-ui/core/Typography";
 import TagManager from "react-gtm-module";
+import {getCookieConsentValue} from "react-cookie-consent";  
 
 
 const GHGI_API_ADDRESS = 'https://api.sexytofu.org/api.ghgi.org:443';
@@ -59,17 +60,20 @@ class App extends Component {
          *
          * @param   {array<Object>}  groceryList  Food items with the signature {"ingredient": String, "quantity": float, "unit": String}
          */
-        // Send data to Google Tag Manager
-        for (let i = 0; i < groceryList.length; i++) {
-            let tagManagerArgs = {
-                dataLayer: {
-                    event: "searchItem",
-                    ingredient: groceryList[i]["ingredient"],
-                    quantity: groceryList[i]["quantity"],
-                    unit: groceryList[i]["unit"]
-                }
-            };
-            TagManager.dataLayer(tagManagerArgs);
+        // Send data to Google Tag Manager if consented to cookies.
+        const isConsent = getCookieConsentValue();
+        if (isConsent === "true") {
+            for (let i = 0; i < groceryList.length; i++) {
+                let tagManagerArgs = {
+                    dataLayer: {
+                        event: "searchItem",
+                        ingredient: groceryList[i]["ingredient"],
+                        quantity: groceryList[i]["quantity"],
+                        unit: groceryList[i]["unit"]
+                    }
+                };
+                TagManager.dataLayer(tagManagerArgs);
+            }
         }
 
         // Copy out groceryList so we don't change the original array
@@ -109,15 +113,17 @@ class App extends Component {
             })
         }
 
-        // Track search and results in Google Tag Manager
-        let tagManagerArgs = {
-            dataLayer: {
-                event: "search",
-                groceryListLength: groceryList.length,
-                results: results
-            }
-        };
-        TagManager.dataLayer(tagManagerArgs);
+        // Track search and results in Google Tag Manager if consented to cookies
+        if (isConsent === "true") {
+            let tagManagerArgs = {
+                dataLayer: {
+                    event: "search",
+                    groceryListLength: groceryList.length,
+                    results: results
+                }
+            };
+            TagManager.dataLayer(tagManagerArgs);
+        }
     }
 
     // TODO: Distinguish between L and KG
@@ -235,15 +241,18 @@ class App extends Component {
             grams: this.state.results.grams[index]
         }});
 
-        // Send data to Google Tag Manager
-        let tagManagerArgs = {
-            dataLayer: {
-                event: "checkReco",
-                ingredient: this.state.results.contributors[index],
-                index: index
-            }
-        };
-        TagManager.dataLayer(tagManagerArgs);
+        // Send data to Google Tag Manager if consented to cookies
+        const isConsent = getCookieConsentValue();
+        if (isConsent === "true") {
+            let tagManagerArgs = {
+                dataLayer: {
+                    event: "checkReco",
+                    ingredient: this.state.results.contributors[index],
+                    index: index
+                }
+            };
+            TagManager.dataLayer(tagManagerArgs);
+        }
     }
     
     componentDidUpdate() {

--- a/frontend/src/Comparison.js
+++ b/frontend/src/Comparison.js
@@ -18,6 +18,7 @@ import avgAmericanIcon from "./assets/summary_graphics/Tofu_avgamerican.png";
 import globalAvgIcon from "./assets/summary_graphics/Tofu_globalavg.png";
 import sexyTofuIcon from "./assets/summary_graphics/Tofu_sexytofu.png";
 import TagManager from "react-gtm-module";
+import {getCookieConsentValue} from "react-cookie-consent";
 
 const boxStyles = {
     /**
@@ -171,14 +172,17 @@ class Comparison extends Component {
          */
         this.setState({numPeople: event.target.value});
 
-        // Send data to Google Tag Manager
-        let tagManagerArgs = {
-            dataLayer: {
-                event: "changeNumPeople",
-                numPeople: event.target.value
-            }
-        };
-        TagManager.dataLayer(tagManagerArgs);
+        // Send data to Google Tag Manager if consented to cookies
+        const isConsent = getCookieConsentValue();
+        if (isConsent === "true") {
+            let tagManagerArgs = {
+                dataLayer: {
+                    event: "changeNumPeople",
+                    numPeople: event.target.value
+                }
+            };
+            TagManager.dataLayer(tagManagerArgs);
+        }
     }
 
     handleNumDaysChange = event => {
@@ -189,14 +193,17 @@ class Comparison extends Component {
          */
         this.setState({numDays: event.target.value});
 
-        // Send data to Google Tag Manager
-        let tagManagerArgs = {
-            dataLayer: {
-                event: "changeNumDays",
-                numDays: event.target.value
-            }
-        };
-        TagManager.dataLayer(tagManagerArgs);
+        // Send data to Google Tag Manager if consented to cookies
+        const isConsent = getCookieConsentValue();
+        if (isConsent === "true") {
+            let tagManagerArgs = {
+                dataLayer: {
+                    event: "changeNumDays",
+                    numDays: event.target.value
+                }
+            };
+            TagManager.dataLayer(tagManagerArgs);
+        }
     }
 
     render() {

--- a/frontend/src/CookieBanner.js
+++ b/frontend/src/CookieBanner.js
@@ -47,7 +47,6 @@ class CookieBanner extends Component {
         // Or refresh the page after decline if previously consented.
         // Ideally, set cookie consent in GTag, see https://developers.google.com/gtagjs/devguide/consent 
         // Same issue as https://github.com/alinemorelli/react-gtm/issues/61
-
       }      
 
     render() {
@@ -64,8 +63,7 @@ class CookieBanner extends Component {
                 buttonStyle={{backgroundColor: '#F2F2F2', color: '#353535', borderRadius: '3px'}}
                 >
                 This website uses cookies to enhance the user experience.&nbsp;
-                <a href="https://info.sexytofu.org/" target="_blank" rel="noopener noreferrer">Learn more</a>. 
-                {/* (TODO: link to privacy policy + allow to decline/accept cookies in privacy policy [or other place] even after banner disappears) */}
+                <a href="/policy/privacyPolicy.html" target="_blank" rel="noopener noreferrer">Learn more</a>.
             </CookieConsent>
         )
     }

--- a/frontend/src/CookieBanner.js
+++ b/frontend/src/CookieBanner.js
@@ -1,0 +1,74 @@
+import React, {Component} from "react";
+import CookieConsent, {getCookieConsentValue, Cookies} from "react-cookie-consent";  
+import TagManager from 'react-gtm-module';
+
+import {withStyles} from "@material-ui/core";
+
+const styles = {
+    root: {
+    },
+}
+
+class CookieBanner extends Component {
+    /**
+     * React class component to get user consent via cookie banner, following cookie banner from:
+     * https://github.com/Mastermindzh/react-cookie-consent#cookie-react-cookie-consent-cookie
+     * @param   {Object}    props.classes           Style of the component
+     */
+    constructor(props) {
+        super(props);
+    }
+
+    componentDidMount() {
+        // Enable cookies if the user accepted on a previous visit.
+        const isConsent = getCookieConsentValue();
+        if (isConsent === "true") {
+            this.handleAcceptCookie();
+        }
+    }
+
+    handleAcceptCookie = () => {
+        // TODO: Add conditional: initialize only if not already initialized - don't want two tags for one user.
+        const tagManagerArgs = {
+            gtmId: 'GTM-K6GPKTV',
+            auth: process.env.GTM_AUTH,
+            preview: process.env.GTM_PREVIEW
+        };
+        TagManager.initialize(tagManagerArgs);
+    }
+
+    handleDeclineCookie = () => {
+        // Remove google analytics cookies if decline. TODO: check if this works, as GTM may work different.
+        Cookies.remove("_ga");
+        Cookies.remove("_gat");
+        Cookies.remove("_gid");
+        // TODO: Unitialize previous tagManager eg. if previously accepted, but now want to decline, then make sure no more tracking.
+        // Worst case: inject script instead of TagManager.init w/ conditional on cookie consent, or check cookie consent every datalayer push.
+        // Or refresh the page after decline if previously consented.
+        // Ideally, set cookie consent in GTag, see https://developers.google.com/gtagjs/devguide/consent 
+        // Same issue as https://github.com/alinemorelli/react-gtm/issues/61
+
+      }      
+
+    render() {
+        // TODO: Advanced region-based consent, eg. automatically disable for residents in CA and EU until consent, but enable for rest of USA
+        // https://developers.google.com/gtagjs/devguide/consent https://support.google.com/tagmanager/answer/10718549?hl=en 
+        return (
+            <CookieConsent
+                // debug={true} 
+                enableDeclineButton onAccept={this.handleAcceptCookie} 
+                onDecline={this.handleDeclineCookie}
+                buttonText="Accept"
+                declineButtonText="Decline"
+                declineButtonStyle={{backgroundColor: 'transparent', color: '#F2F2F2', borderRadius: '3px', border: '2px solid #F2F2F2'}}
+                buttonStyle={{backgroundColor: '#F2F2F2', color: '#353535', borderRadius: '3px'}}
+                >
+                This website uses cookies to enhance the user experience.&nbsp;
+                <a href="https://info.sexytofu.org/" target="_blank" rel="noopener noreferrer">Learn more</a>. 
+                {/* (TODO: link to privacy policy + allow to decline/accept cookies in privacy policy [or other place] even after banner disappears) */}
+            </CookieConsent>
+        )
+    }
+}
+
+export default withStyles(styles)(CookieBanner);

--- a/frontend/src/CookieBanner.js
+++ b/frontend/src/CookieBanner.js
@@ -11,8 +11,7 @@ const styles = {
 
 class CookieBanner extends Component {
     /**
-     * React class component to get user consent via cookie banner, following cookie banner from:
-     * https://github.com/Mastermindzh/react-cookie-consent#cookie-react-cookie-consent-cookie
+     * React class component to get user consent via cookie banner.
      * @param   {Object}    props.classes           Style of the component
      */
     constructor(props) {
@@ -28,7 +27,6 @@ class CookieBanner extends Component {
     }
 
     handleAcceptCookie = () => {
-        // TODO: Add conditional: initialize only if not already initialized - don't want two tags for one user.
         const tagManagerArgs = {
             gtmId: 'GTM-K6GPKTV',
             auth: process.env.GTM_AUTH,
@@ -42,12 +40,9 @@ class CookieBanner extends Component {
         Cookies.remove("_ga");
         Cookies.remove("_gat");
         Cookies.remove("_gid");
-        // TODO: Unitialize previous tagManager eg. if previously accepted, but now want to decline, then make sure no more tracking.
-        // Worst case: inject script instead of TagManager.init w/ conditional on cookie consent, or check cookie consent every datalayer push.
-        // Or refresh the page after decline if previously consented.
-        // Ideally, set cookie consent in GTag, see https://developers.google.com/gtagjs/devguide/consent 
-        // Same issue as https://github.com/alinemorelli/react-gtm/issues/61
-      }      
+        // TODO: better way of stopping GTM tracking than current setup (checking cookie consent before dataLayer push), 
+        // which works across pages eg. can also set from privacy policy page? 
+    }
 
     render() {
         // TODO: Advanced region-based consent, eg. automatically disable for residents in CA and EU until consent, but enable for rest of USA

--- a/frontend/src/GroceryList.js
+++ b/frontend/src/GroceryList.js
@@ -13,6 +13,7 @@ import { withTheme } from "@material-ui/styles";
 import { color } from "chart.js/helpers";
 
 import TagManager from 'react-gtm-module'
+import {getCookieConsentValue} from "react-cookie-consent";
 import { ContactSupport } from "@material-ui/icons";
 
 
@@ -335,16 +336,19 @@ class GroceryList extends Component {
                             popperMsg: `We can't find "${parsed['names'][0]}", but we will still add it to your list without its carbon footprint. We are working hard to provide data for more food!`
                         });
 
-                        // Send data to Google Tag Manager
-                        let tagManagerArgs = {
-                            dataLayer: {
-                                event: "dataNotFound",
-                                gtm: {
-                                    errorMessage: this.state.popperMsg
+                        // Send data to Google Tag Manager if consented to cookies
+                        const isConsent = getCookieConsentValue();
+                        if (isConsent === "true") {
+                            let tagManagerArgs = {
+                                dataLayer: {
+                                    event: "dataNotFound",
+                                    gtm: {
+                                        errorMessage: this.state.popperMsg
+                                    }
                                 }
-                            }
-                        };
-                        TagManager.dataLayer(tagManagerArgs);
+                            };
+                            TagManager.dataLayer(tagManagerArgs);
+                        }
                     }
                 }
             }).catch(err => {
@@ -357,16 +361,19 @@ class GroceryList extends Component {
             this.showSearchError(errorMessage);
             console.warn("Something went wrong, default grams wasn't retrievable from GHGI.");
 
-            // Send data to Google Tag Manager
-            let tagManagerArgs = {
-                dataLayer: {
-                    event: "dataNotFound",
-                    gtm: {
-                        errorMessage: errorMessage
+            // Send data to Google Tag Manager if consented to cookies
+            const isConsent = getCookieConsentValue();
+            if (isConsent === "true") {
+                let tagManagerArgs = {
+                    dataLayer: {
+                        event: "dataNotFound",
+                        gtm: {
+                            errorMessage: errorMessage
+                        }
                     }
-                }
-            };
-            TagManager.dataLayer(tagManagerArgs);
+                };
+                TagManager.dataLayer(tagManagerArgs);
+            }
 
             return;
         }
@@ -401,17 +408,20 @@ class GroceryList extends Component {
             "quantity": quantity,
             "unit": unit});
 
-        // Send data to Google Tag Manager
-        let tagManagerArgs = {
-            dataLayer: {
-                event: "parsingComplete",
-                query: this.state.currentQuery,
-                ingredient: ingredient,
-                quantity: quantity,
-                unit: unit
-            }
-        };
-        TagManager.dataLayer(tagManagerArgs);
+        // Send data to Google Tag Manager if consented to cookies
+        const isConsent = getCookieConsentValue();
+        if (isConsent === "true") {
+            let tagManagerArgs = {
+                dataLayer: {
+                    event: "parsingComplete",
+                    query: this.state.currentQuery,
+                    ingredient: ingredient,
+                    quantity: quantity,
+                    unit: unit
+                }
+            };
+            TagManager.dataLayer(tagManagerArgs);
+        }
 
         // Set React state
         this.setState({groceryList: groceryList, currentQuery: ""});
@@ -441,14 +451,17 @@ class GroceryList extends Component {
          */
         let groceryList = this.state.groceryList;
 
-        // Send data to Google Tag Manager
-        let tagManagerArgs = {
-            dataLayer: {
-                event: "removeItem",
-                ingredient: groceryList[index]["ingredient"],
-            }
-        };
-        TagManager.dataLayer(tagManagerArgs);
+        // Send data to Google Tag Manager if consented to cookies
+        const isConsent = getCookieConsentValue();
+        if (isConsent === "true") {
+            let tagManagerArgs = {
+                dataLayer: {
+                    event: "removeItem",
+                    ingredient: groceryList[index]["ingredient"],
+                }
+            };
+            TagManager.dataLayer(tagManagerArgs);
+        }
 
         // Remove item from grocery list
         groceryList.splice(index, 1);

--- a/frontend/src/Recommendations.js
+++ b/frontend/src/Recommendations.js
@@ -10,6 +10,7 @@ import {joinText} from "./utils.js"
 
 import FavoriteIcon from '@material-ui/icons/Favorite';
 import TagManager from "react-gtm-module";
+import {getCookieConsentValue} from "react-cookie-consent";
 
 
 const NATIVE_API_ADDRESS =  process.env.API_HOST || "http://localhost:8000";
@@ -129,18 +130,21 @@ class Recommendations extends Component {
                 }
             }
 
-            // Send data to Google Tag Manager
-            let tagManagerArgs = {
-                dataLayer: {
-                    event: "showReco",
-                    ingredient: this.props.food.alias,
-                    recommendation: reco.text_short,
-                    has_recipe: reco.has_recipe,
-                    replacement: reco['replacement_food_name'],
-                    impact_variant: random_group
-                }
-            };
-            TagManager.dataLayer(tagManagerArgs);
+            // Send data to Google Tag Manager if consented to cookies
+            const isConsent = getCookieConsentValue();
+            if (isConsent === "true") {
+                let tagManagerArgs = {
+                    dataLayer: {
+                        event: "showReco",
+                        ingredient: this.props.food.alias,
+                        recommendation: reco.text_short,
+                        has_recipe: reco.has_recipe,
+                        replacement: reco['replacement_food_name'],
+                        impact_variant: random_group
+                    }
+                };
+                TagManager.dataLayer(tagManagerArgs);
+            }
         }
 
         return {__html: reco_text};
@@ -198,15 +202,18 @@ class Recommendations extends Component {
         let reco = this.state.recos[this.state.indexOnDisplay];
         this.props.updateGroceryList(this.props.food.alias, 'ingredient', reco['replacement_food_name']);
 
-        // Send data to Google Tag Manager
-        let tagManagerArgs = {
-            dataLayer: {
-                event: "applyReco",
-                ingredient: this.props.food.alias,
-                replacement: reco['replacement_food_name']
-            }
-        };
-        TagManager.dataLayer(tagManagerArgs);
+        // Send data to Google Tag Manager if consented to cookies
+        const isConsent = getCookieConsentValue();
+        if (isConsent === "true") {
+            let tagManagerArgs = {
+                dataLayer: {
+                    event: "applyReco",
+                    ingredient: this.props.food.alias,
+                    replacement: reco['replacement_food_name']
+                }
+            };
+            TagManager.dataLayer(tagManagerArgs);
+        }
     }
 
     nextReco = () => {
@@ -217,14 +224,17 @@ class Recommendations extends Component {
         let newIndex = (this.state.indexOnDisplay + 1) % this.state.recos.length;
         this.setState({indexOnDisplay: newIndex});
 
-        // Send data to Google Tag Manager
-        let tagManagerArgs = {
-            dataLayer: {
-                event: "nextReco",
-                index: newIndex
-            }
-        };
-        TagManager.dataLayer(tagManagerArgs);
+        // Send data to Google Tag Manager if consented to cookies
+        const isConsent = getCookieConsentValue();
+        if (isConsent === "true") {
+            let tagManagerArgs = {
+                dataLayer: {
+                    event: "nextReco",
+                    index: newIndex
+                }
+            };
+            TagManager.dataLayer(tagManagerArgs);
+        }
     }
 
     render() {

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -4,15 +4,6 @@ import App from './App';
 import './index.css';
 import  "regenerator-runtime";
 
-import TagManager from 'react-gtm-module'
-
-const tagManagerArgs = {
-    gtmId: 'GTM-K6GPKTV',
-    auth: process.env.GTM_AUTH,
-    preview: process.env.GTM_PREVIEW
-};
-TagManager.initialize(tagManagerArgs)
-
 ReactDOM.render(<App />, document.getElementById('app'));
 
 

--- a/frontend/src/policy/PrivacyPolicyApp.js
+++ b/frontend/src/policy/PrivacyPolicyApp.js
@@ -1,0 +1,204 @@
+import React, { Component } from 'react';
+import  "regenerator-runtime";
+import {getCookieConsentValue, Cookies} from "react-cookie-consent";  
+
+import {Grid} from '@material-ui/core';
+import {Typography} from '@material-ui/core';
+import Switch from '@material-ui/core/Switch';
+import {withStyles} from '@material-ui/core';
+import {MuiThemeProvider, createMuiTheme} from '@material-ui/core/styles';
+
+const styles = {
+    root: {
+        rowGap: '50px',
+        padding: '50px 100px',
+        '@media only screen and (max-width: 600px)': {
+            padding: '50px 20px',
+        },
+        '& a:link' : {
+            color: '#851fff',
+        },
+        '& a:visited': {
+            color: '#cc00aa',
+        },
+        '& a:link:hover': {
+            backgroundColor: '#e6d1ff',
+            color: '#6c00ed',
+        },
+        '& a:visited:hover': {
+            backgroundColor: '#ffdbec',
+            color: '#99007f',
+        },
+    },
+};
+
+
+class PrivacyPolicyApp extends Component {
+    /**
+     * Top-level React class component for the main body of the Privacy Policy.
+     *
+     * @param   {Object}  classes  Style of the component
+     */
+    constructor(props){
+        super(props);
+        this.state = {
+            isConsent : (getCookieConsentValue() === 'true')
+        }
+    }    
+
+    handleChange = () => {
+        // Sets cookie according to checkbox.
+        // NOTE: setState is asynchronous, so storing the value in a variable allows both cookies and state to be set to the same value.
+        // https://stackoverflow.com/questions/32923255/react-checkbox-doesnt-toggle
+        const consent = !this.state.isConsent;
+        this.setState({isConsent: consent});
+        Cookies.set("CookieConsent", consent, { expires: 365 });
+        // TODO: change google tag manager tracking WITHOUT having to reload the page. (communication between this and index.html?)
+    }
+
+    render () {
+        // Override global themes for Typography. TODO: place in separate imported doc. like index.css, import same as App.js
+        const theme = createMuiTheme({
+        typography: {
+            h3: {
+                fontFamily: ['Lato', 'sans-serif'],
+                fontWeight: 'bolder',
+                fontSize: '1.5rem',
+                color: 'white',
+            },
+            h5: {
+                fontFamily: ['Lato', 'sans-serif'],
+                fontWeight: 'bold',
+                color: 'white',
+            },
+            body2: {
+                fontFamily: ['Lato', 'sans-serif'],
+                fontWeight: 'normal',
+                fontSize: '1.2rem',
+            }
+        }
+        });
+
+        const LAST_UPDATED_DATE = "August 28 2021";
+        return (
+            <MuiThemeProvider theme={theme}>
+            <Grid container id="container" className={this.props.classes.root}>
+                <Grid item xs={12} id="input">
+                        <Typography variant="h3" align="center" style={{color: "#322737"}}> 
+                            Privacy Policy
+                        </Typography>
+                        <Typography component={'span'} variant="body2" display="block" align="left" style={{marginBottom: '1rem'}}>
+                        Last updated: <b>{LAST_UPDATED_DATE}</b>
+                        </Typography>
+                        <Typography component={'span'} variant="body2" display="block" align="left" style={{marginBottom: '1rem'}}>
+                            <b>Sexy Tofu</b> operates <a href="https://www.sexytofu.org/" target="_blank" rel="noopener noreferrer">https://www.sexytofu.org/</a> (the "Site").
+                            This privacy policy informs you of our policies regarding the collection, use and disclosure of
+                            personal information we receive from users of the Site.
+                            We use your personal information only for providing and improving the Site. By using the Site, you
+                            agree to the collection and use of information in accordance with this policy.
+                        </Typography>
+                        <Typography component={'span'} variant="h3" display="block" align="left" style={{color: "#322737", marginBottom: '1rem'}}>
+                            Cookies
+                        </Typography>
+                        <Typography component={'span'} variant="body2" display="block" align="left" style={{marginBottom: '1rem'}}>
+                            Cookies are small files of data, which may include an anonymous unique identifier.
+                            Cookies are sent to your browser from a web site and stored on your computer's hard drive.
+                            Like many sites, we use "cookies" to collect information about your activities
+                            in our services, which may include:
+                            <ul>
+                                <li> Foods you search for</li>
+                                <li> Recommendations you apply</li>
+                                <li> Number of people and length of time your grocery list is for </li>
+                            </ul>
+                            We use cookies from third-party partners, such as&nbsp;
+                            <a href="https://www.google.com/policies/privacy/partners/" target="_blank" rel="noopener noreferrer">Google Analytics</a>,&nbsp;
+                            to track how you use this website so we may improve this website in the future.
+                            You can instruct your browser to refuse all cookies or to indicate when a cookie is being sent.
+                            The amount of information provided by you is voluntary.
+                            However, if you do not accept cookies, you might not be able to use some parts of our Site.
+                        </Typography>
+                        <Typography component={'span'} variant="h3" display="block" align="left" style={{color: "#322737", marginBottom: '1rem'}}>
+                            Your Data
+                        </Typography>
+                        <Typography component={'span'} variant="body2" display="block" align="left" style={{marginBottom: '1rem'}}>
+                            Please note <b>Sexy Tofu</b> takes privacy seriously. Data collected is used for internal purposes only.
+                            We do not sell or rent information about you.
+                            We do not share or disclose your personal information and data to
+                            third parties without your consent, except as explained in this Privacy Policy.
+                        </Typography>
+                        <Typography component={'span'} variant="h3" display="block" align="left" style={{color: "#322737", marginBottom: '1rem'}}>
+                            Compliance with Laws
+                        </Typography>
+                        <Typography component={'span'} variant="body2" display="block" align="left" style={{marginBottom: '1rem'}}>
+                            <b>Sexy Tofu</b> cooperates with the law and government officials to comply with the law. We may disclose
+                            information about you if we deem it reasonably necessary to:
+                            <ol type="a">
+                                <li> Satisfy relevant laws or regulations</li>
+                                <li> Enforce Terms of Use, including investigations of potential violations</li>
+                                {/* TODO: a Terms of Use, and link here */}
+                                <li> Detect, prevent, and address fraud, security, or technical issues</li>
+                                <li> Protect the rights, safety, and property of this company, its users, or the public</li>
+                            </ol>
+                            as required or permitted by law.
+                            Your data is subject to the laws of the United States of America regardless of where the data originates.
+                        </Typography>
+                        <Typography component={'span'} variant="h3" display="block" align="left" style={{color: "#322737", marginBottom: '1rem'}}>
+                            Security
+                        </Typography>
+                        <Typography component={'span'} variant="body2" display="block" align="left" style={{marginBottom: '1rem'}}>
+                            The security of your personal information is important to us, but remember that no method of transmission over the internet,
+                            or method of electronic storage, is always completely secure.
+                            While we strive to use commercially acceptable means to protect your Personal Information,
+                            we cannot guarantee its absolute security.
+                        </Typography>
+                        <Typography component={'span'} variant="h3" display="block" align="left" style={{color: "#322737", marginBottom: '1rem'}}>
+                            Changes to this privacy policy
+                        </Typography>
+                        <Typography component={'span'} variant="body2" display="block" align="left" style={{marginBottom: '1rem'}}>
+                            This Privacy Policy is effective as of <b>{LAST_UPDATED_DATE}</b> and will remain in effect
+                            except with respect to any changes in its provisions in the future,
+                            which will be in effect immediately after being posted on this page.
+                            We reserve the right to update or change our Privacy Policy at any time and
+                            you should check this Privacy Policy periodically. Your continued use of the Service
+                            after we post any modifications to the Privacy Policy on this
+                            page will constitute your acknowledgment of the modifications and your consent
+                            to abide and be bound by the modified Privacy Policy.
+                        </Typography>
+                        <Typography component={'span'} variant="h3" display="block" align="left" style={{color: "#322737", marginBottom: '1rem'}}>
+                            Contact us
+                        </Typography>
+                        <Typography component={'span'} variant="body2" display="block" align="left" style={{marginBottom: '1rem'}}>
+                            If you have any questions about this Privacy Policy, please&nbsp;
+                            <a href="mailto: sexytofu.info@gmail.com">contact us</a>.
+                        </Typography>
+                </Grid>
+                {/* Only show if already accepted/declined cookie values in banner. */}
+                {(getCookieConsentValue() !== undefined) && <Grid item xs={12} id="change-cookie-preference">
+                    <Typography
+                        align='center'
+                        variant='h3'
+                        color='textPrimary'>
+                        Change your cookie preferences
+                    </Typography>
+                    <Typography component={'span'} variant="body2" display="block" align="left" style={{color: "#322737", marginBottom: '1rem'}}>
+                        You can update your cookie preference here.
+                        You have previously {this.state.isConsent ? "accepted" : "declined"} cookies. 
+                    </Typography>
+                    <Typography component={'span'} variant="body2" display="block" align="left" style={{color: "#322737", marginBottom: '1rem'}}>
+                        <Switch
+                            checked={this.state.isConsent}
+                            onChange={this.handleChange}
+                            name="cookie-consent-switch"
+                            inputProps={{ 'aria-label': 'cookie consent checkbox' }}
+                        />
+                        Accept cookies?
+                    </Typography>
+                </Grid>
+                }
+            </Grid>
+            </MuiThemeProvider>
+        );
+    }
+}
+
+export default withStyles(styles)(PrivacyPolicyApp);

--- a/frontend/src/policy/PrivacyPolicyApp.js
+++ b/frontend/src/policy/PrivacyPolicyApp.js
@@ -53,7 +53,6 @@ class PrivacyPolicyApp extends Component {
         const consent = !this.state.isConsent;
         this.setState({isConsent: consent});
         Cookies.set("CookieConsent", consent, { expires: 365 });
-        // TODO: change google tag manager tracking WITHOUT having to reload the page. (communication between this and index.html?)
     }
 
     render () {

--- a/frontend/src/policy/privacyPolicy.html
+++ b/frontend/src/policy/privacyPolicy.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
+        <meta name="robots" content="noindex">
+        <link rel="shortcut icon" type="image/x-icon" href="../favicon.ico">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Sexy Tofu: Privacy Policy</title>
+    </head>
+    <body>
+        <div id="privacy-policy"></div>
+        <script src="privacyPolicy.js"></script>
+    </body>
+</html>

--- a/frontend/src/policy/privacyPolicy.js
+++ b/frontend/src/policy/privacyPolicy.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import PrivacyPolicyApp from './PrivacyPolicyApp';
+import  "regenerator-runtime";
+
+ReactDOM.render(<PrivacyPolicyApp />, document.getElementById('privacy-policy'));


### PR DESCRIPTION
Features:
- cookie consent banner
- separate privacy policy page
- ability to change cookie preference after banner disappears

Issues:

- Currently, it checks cookie consent every GTM datalayer push. However, this requires importing cookies and extra lines of code when you want to send data. Ideally, find a better way of uninitializing previous tagManager or preventing tracking if change to decline cookies without requiring refresh of page, and be able to do so from a separate page as well.
       See: https://developers.google.com/gtagjs/devguide/consent 
       Same issue as: https://github.com/alinemorelli/react-gtm/issues/61

- Will need to link this privacy policy page to the previous pull request #25 instead of the popup (unless you prefer popup?)

Question

- What is the difference between using [parcel.js](https://parceljs.org/getting_started.html) / package.json versus [Router](https://reactrouter.com/) to change React webpages?
- How would you change the URL name. For example, right now the privacy policy page is at ".com/policy/privacyPolicy.html". How would I change it to another name like ".com/privacyPolicy"